### PR TITLE
Userモデルにedit,destroyを実装

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -97,3 +97,5 @@ body {
 hr {
     border-top: 1px solid #9E9E9E;
 }
+
+li {  list-style: none;  }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,10 @@ class UsersController < ApplicationController
   before_action :logged_in_user, only: [:edit, :update, :destroy]
   before_action :correct_user , only: [:edit, :destroy]
   
+  def index 
+    @users = User.paginate(page: params[:page])
+  end
+  
   def new
     @user = User.new
   end
@@ -24,11 +28,24 @@ class UsersController < ApplicationController
     end
   end
   
-  def index 
-  end
-  
   def edit
     @user = User.find(params[:id])
+  end
+  
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+      flash[:success] = "プロフィールを更新しました。"
+      redirect_to user_path @user
+    else
+      render 'edit'
+    end
+  end
+  
+  def destroy
+    User.find(params[:id]).destroy
+    flash[:success] = "User deleted"
+    redirect_to users_url
   end
   
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
   
   def User.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if model && model.errors.any? %>
-  <div class="alert alert-warning">
+  <div class="alert alert-warning text-left">
     <ul>
       <% model.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/layouts/_header_loggedin.html.erb
+++ b/app/views/layouts/_header_loggedin.html.erb
@@ -2,7 +2,7 @@
   <%= image_tag "logo.png" , { class: "img-fluid tsumiage"} %>
 <% end %>
 <nav class="nav my-2 my-md-0 mr-md-3">
-  <%= link_to "Users", "#", { class: "nav-link p-2 text-dark" } %>
+  <%= link_to "Users", users_path, { class: "nav-link p-2 text-dark" } %>
   <%= link_to "Posts", "#" , { class: "nav-link p-2 text-dark" } %>
   <div class="dropdown">
     <button type="button" class="btn btn-dark-blue dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,6 +3,8 @@
   <h1 class="col-12 h3 mb-3 font-weight-normal">ユーザー情報の編集</h1>
     <div class="signin col-md-6 col-md-offset-3">
       <%= form_for(@user) do |f| %>
+        <%= render 'layouts/error_messages' , model: f.object %>
+      
         <%= f.text_field :name ,{ placeholder: "ユーザー名", class: "form-control mb-2" } %>
   
         <%= f.email_field :email ,{ placeholder: "メールアドレス", class: "form-control mb-2" } %>
@@ -12,5 +14,13 @@
         <%= f.password_field :password_confirmation ,{ placeholder: "パスワード（確認）", class: "form-control mb-2" } %>
         <%= f.submit "登録", class: "btn btn-primary btn-lg btn-block" %>
       <% end %>
+      
+      <% if current_user?(@user) %>
+        <button class="btn btn-pink-moon btn-outline-danger btn-rounded btn-sm  mt-5">
+          <%= link_to "アカウントを削除", @user, method: :delete, class: "text-dark",
+          data: { confirm: "アカウントを削除するともとに戻せません。本当に削除しますか？" } %>
+        </button>
+      <% end %>
+      
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,11 @@
+<%= will_paginate %>
+
+<ul class="users">
+  <% @users.each do |user| %>
+    <li>
+      <%= link_to user.name, user %>
+    </li>
+  <% end %>
+</ul>
+
+<%= will_paginate %>


### PR DESCRIPTION
・Userモデルのedit, destroyアクションを実装しました。
　（ログインしているユーザーが自身のedit画面でdeleteリクエストを発行できる）
・Userのindexですべてのユーザーをwill_paginagteで表示する機能を実装しました。
・テストは未完成です。